### PR TITLE
fix(solver): correct TX-direction sign in vectorized track residual

### DIFF
--- a/retina_geolocator/lm_solver_track.py
+++ b/retina_geolocator/lm_solver_track.py
@@ -34,9 +34,9 @@ def _residual_vec(state, dt, obs_delay, obs_doppler, tx, rx, dist_tx_rx,
     pz = z0 + vz_km * dt
 
     # Bistatic delay  (vectorised)
-    dx_tx = px - tx[0]
-    dy_tx = py - tx[1]
-    dz_tx = pz - tx[2]
+    dx_tx = tx[0] - px
+    dy_tx = tx[1] - py
+    dz_tx = tx[2] - pz
     dx_rx = rx[0] - px
     dy_rx = rx[1] - py
     dz_rx = rx[2] - pz

--- a/retina_geolocator/multinode_solver.py
+++ b/retina_geolocator/multinode_solver.py
@@ -196,7 +196,10 @@ def _jacobian_function(state, node_setups, measurements, z_fixed_km):
     return np.array(rows, dtype=np.float64)
 
 
-def solve_multinode(solver_input, node_configs):
+def solve_multinode(solver_input, node_configs,
+                    v_max_ms: float = 300.0,
+                    sigma_min_floor: float = 0.05,
+                    rail_eps_ms: float = 5.0):
     """Solve for target position using multi-node measurements.
 
     Args:
@@ -288,9 +291,9 @@ def solve_multinode(solver_input, node_configs):
     # to zero and triggering immediate false-convergence on the first step.
     x0 = np.array([0.0, 0.0, 0.0, 0.0, 0.0])
 
-    # Bounds: horizontal position ±60 km from guess, velocity ±300 m/s
-    lb = [x0[0] - 60, x0[1] - 60, -300, -300, -100]
-    ub = [x0[0] + 60, x0[1] + 60,  300,  300,  100]
+    # Bounds: horizontal position ±60 km from guess, velocity ±v_max_ms
+    lb = [x0[0] - 60, x0[1] - 60, -v_max_ms, -v_max_ms, -100]
+    ub = [x0[0] + 60, x0[1] + 60,  v_max_ms,  v_max_ms,  100]
 
     try:
         # `loss="huber"` — robust regression instead of plain L2.
@@ -353,6 +356,23 @@ def solve_multinode(solver_input, node_configs):
     rms_delay = float(np.sqrt(np.mean(np.array(delay_residuals) ** 2)))
     rms_doppler = float(np.sqrt(np.mean(np.array(doppler_residuals) ** 2)))
 
+    # Velocity-observability guard. The bistatic Doppler Jacobian rows are
+    # b_i = û(T→TX)+û(T→RX); near-colinear receivers make them near-parallel, so
+    # velocity is unobservable and the bounded solve rails to the ±v_max corner
+    # (the 825 kt artifact). Detect via the smallest singular value of B; when
+    # also at the bound, drop the velocity but keep the (still valid) position.
+    B = np.empty((len(measurements), 2))
+    for i, m in enumerate(measurements):
+        ns = node_setups[m.node_id]
+        tx, rx = ns.tx_enu, ns.rx_enu
+        dptx = math.sqrt((px - tx[0]) ** 2 + (py - tx[1]) ** 2 + (pz - tx[2]) ** 2)
+        dprx = math.sqrt((px - rx[0]) ** 2 + (py - rx[1]) ** 2 + (pz - rx[2]) ** 2)
+        B[i, 0] = (tx[0] - px) / dptx + (rx[0] - px) / dprx
+        B[i, 1] = (tx[1] - py) / dptx + (rx[1] - py) / dprx
+    sigma_min = float(np.linalg.svd(B, compute_uv=False).min())
+    speed_ms = math.hypot(float(state[2]), float(state[3]))
+    velocity_observable = not (sigma_min < sigma_min_floor and speed_ms > v_max_ms - rail_eps_ms)
+
     # Convert solution ENU back to LLA (z is fixed)
     lat, lon, alt_m = _enu_km_to_lla(
         state[0], state[1], z_fixed_km,
@@ -364,9 +384,10 @@ def solve_multinode(solver_input, node_configs):
         "lat": float(lat),
         "lon": float(lon),
         "alt_m": float(alt_m),
-        "vel_east": float(state[2]),
-        "vel_north": float(state[3]),
-        "vel_up": float(state[4]),
+        "vel_east": float(state[2]) if velocity_observable else 0.0,
+        "vel_north": float(state[3]) if velocity_observable else 0.0,
+        "vel_up": float(state[4]) if velocity_observable else 0.0,
+        "velocity_observable": velocity_observable,
         "rms_delay": rms_delay,
         "rms_doppler": rms_doppler,
         "n_nodes": len(node_setups),

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -12,6 +12,7 @@ from retina_geolocator.multinode_solver import (
     solve_multinode,
 )
 from retina_geolocator.bistatic_models import bistatic_delay, bistatic_doppler
+from retina_geolocator.lm_solver_track import _residual_vec
 
 
 # ── Coordinate conversions ────────────────────────────────────────────────────
@@ -85,6 +86,43 @@ class TestBistaticModels:
             100e6,
         )
         assert abs(doppler) > 1.0
+
+    def test_vectorized_track_residual_matches_reference_doppler(self):
+        state = np.array([10.0, -5.0, 3.0, 120.0, 80.0, 5.0])
+        dt = np.array([0.0, 1.0, 2.0])
+        tx = np.array([20.0, 8.0, 0.2])
+        rx = np.array([0.0, 0.0, 0.0])
+        frequency = 195e6
+
+        obs_delay = []
+        obs_doppler = []
+        for t in dt:
+            pos = np.array([
+                state[0] + state[3] / 1000 * t,
+                state[1] + state[4] / 1000 * t,
+                state[2] + state[5] / 1000 * t,
+            ])
+            obs_delay.append(bistatic_delay(pos, tx, rx))
+            obs_doppler.append(bistatic_doppler(pos, state[3:], tx, rx, frequency))
+
+        residuals = _residual_vec(
+            state,
+            dt,
+            np.array(obs_delay),
+            np.array(obs_doppler),
+            tx,
+            rx,
+            np.linalg.norm(rx - tx),
+            frequency,
+            frequency / 299792.458,
+            None,
+            0.0,
+            0.0,
+            np.empty(len(dt) * 3),
+        )
+
+        assert np.max(np.abs(residuals[0::3])) < 1e-9
+        assert np.max(np.abs(residuals[1::3])) < 1e-9
 
 
 # ── Residual function ─────────────────────────────────────────────────────────

--- a/tests/test_velocity_guard.py
+++ b/tests/test_velocity_guard.py
@@ -1,0 +1,128 @@
+"""Velocity-observability guard in solve_multinode.
+
+Near-colinear receivers make the bistatic Doppler Jacobian rows near-parallel,
+so velocity is unobservable and the bounded solve rails to the ±v_max corner
+(the 825 kt artifact). The guard detects this via the smallest singular value of
+the geometry matrix together with a railed speed: it zeroes the velocity and
+flags velocity_observable=False while keeping the still-valid position. A
+well-conditioned ring must keep its solved velocity and report True.
+"""
+
+import math
+
+import pytest
+
+from retina_geolocator.multinode_solver import _lla_to_enu_km, solve_multinode
+from retina_geolocator.bistatic_models import bistatic_delay, bistatic_doppler
+
+
+def _synthetic_input(node_configs, target_lat, target_lon, target_alt_km,
+                     vel_east=0.0, vel_north=0.0, vel_up=0.0):
+    ref_lat, ref_lon = target_lat, target_lon
+    target_enu = _lla_to_enu_km(target_lat, target_lon, target_alt_km * 1000,
+                                ref_lat, ref_lon, 0.0)
+    measurements = []
+    for nid, cfg in node_configs.items():
+        rx_enu = _lla_to_enu_km(cfg["rx_lat"], cfg["rx_lon"],
+                                cfg["rx_alt_ft"] * 0.3048, ref_lat, ref_lon, 0.0)
+        tx_enu = _lla_to_enu_km(cfg["tx_lat"], cfg["tx_lon"],
+                                cfg["tx_alt_ft"] * 0.3048, ref_lat, ref_lon, 0.0)
+        fc = cfg.get("fc_hz", 100e6)
+        measurements.append({
+            "node_id": nid,
+            "delay_us": bistatic_delay(target_enu, tx_enu, rx_enu),
+            "doppler_hz": bistatic_doppler(target_enu, (vel_east, vel_north, vel_up),
+                                           tx_enu, rx_enu, fc),
+            "snr": 15.0,
+        })
+    return {
+        "initial_guess": {"lat": target_lat + 0.01, "lon": target_lon + 0.01,
+                          "alt_km": target_alt_km},
+        "measurements": measurements,
+        "n_nodes": len(node_configs),
+        "timestamp_ms": 1700000000000,
+    }
+
+
+def _ring_configs(core_lat=32.8968, core_lon=-97.0380, radius_km=18.0,
+                  bearings=(0.0, 120.0, 240.0)):
+    R = 6371.0
+    configs = {}
+    for i, brg in enumerate(bearings):
+        br = math.radians(brg)
+        dlat = (radius_km * math.cos(br)) / R
+        dlon = (radius_km * math.sin(br)) / (R * math.cos(math.radians(core_lat)))
+        configs[f"ring-{i}"] = {
+            "rx_lat": core_lat + math.degrees(dlat),
+            "rx_lon": core_lon + math.degrees(dlon),
+            "rx_alt_ft": 300,
+            "tx_lat": 32.7806, "tx_lon": -96.8006, "tx_alt_ft": 1600,
+            "fc_hz": 195e6,
+        }
+    return configs
+
+
+_COLINEAR_CONFIGS = {
+    "node_a": {"rx_lat": 40.7128, "rx_lon": -74.0060, "rx_alt_ft": 100,
+               "tx_lat": 40.78, "tx_lon": -73.95, "tx_alt_ft": 500, "fc_hz": 100e6},
+    "node_b": {"rx_lat": 40.7138, "rx_lon": -74.0050, "rx_alt_ft": 110,
+               "tx_lat": 40.781, "tx_lon": -73.949, "tx_alt_ft": 500, "fc_hz": 100e6},
+}
+
+
+class TestKeyAlwaysPresent:
+    def test_well_conditioned_result_has_observable_key(self):
+        s_in = _synthetic_input(_ring_configs(), 32.8968, -97.0380, 8.0,
+                                vel_east=150.0, vel_north=80.0)
+        result = solve_multinode(s_in, _ring_configs())
+        assert result is not None
+        assert "velocity_observable" in result
+        assert math.isfinite(result["vel_east"])
+        assert math.isfinite(result["vel_north"])
+
+    def test_colinear_result_has_observable_key(self):
+        s_in = _synthetic_input(_COLINEAR_CONFIGS, 40.73, -73.95, 8.0)
+        result = solve_multinode(s_in, _COLINEAR_CONFIGS)
+        assert result is not None
+        assert "velocity_observable" in result
+
+
+class TestGuardFires:
+    def test_railed_unobservable_velocity_is_zeroed(self):
+        s_in = _synthetic_input(_COLINEAR_CONFIGS, 40.73, -73.95, 8.0,
+                                vel_east=2000.0, vel_north=2000.0)
+        result = solve_multinode(s_in, _COLINEAR_CONFIGS,
+                                 sigma_min_floor=1e9, v_max_ms=30.0)
+        assert result is not None
+        assert result["velocity_observable"] is False
+        assert result["vel_east"] == 0.0
+        assert result["vel_north"] == 0.0
+        assert result["vel_up"] == 0.0
+
+    def test_position_kept_when_velocity_dropped(self):
+        s_in = _synthetic_input(_COLINEAR_CONFIGS, 40.73, -73.95, 8.0,
+                                vel_east=2000.0, vel_north=2000.0)
+        result = solve_multinode(s_in, _COLINEAR_CONFIGS,
+                                 sigma_min_floor=1e9, v_max_ms=30.0)
+        assert result["velocity_observable"] is False
+        assert abs(result["lat"] - 40.73) < 0.1
+        assert abs(result["lon"] - (-73.95)) < 0.1
+
+
+class TestGuardDoesNotOverFire:
+    def test_well_conditioned_ring_keeps_velocity(self):
+        s_in = _synthetic_input(_ring_configs(), 32.8968, -97.0380, 8.0,
+                                vel_east=150.0, vel_north=80.0)
+        result = solve_multinode(s_in, _ring_configs())
+        assert result is not None
+        assert result["velocity_observable"] is True
+        speed = math.hypot(result["vel_east"], result["vel_north"])
+        assert speed > 100.0
+
+    def test_default_params_do_not_zero_modest_velocity(self):
+        s_in = _synthetic_input(_COLINEAR_CONFIGS, 40.73, -73.95, 8.0,
+                                vel_east=50.0, vel_north=30.0)
+        result = solve_multinode(s_in, _COLINEAR_CONFIGS)
+        assert result is not None
+        assert result["velocity_observable"] is True
+        assert result["vel_east"] != 0.0 or result["vel_north"] != 0.0


### PR DESCRIPTION
## Problem
Aircraft tracks froze on the map: fitted ground speed collapsed to ~0.

## Cause
`_residual_vec` built the target->TX unit vector with inverted sign (`px - tx` instead of `tx - px`); the RX side was correct. The Doppler model is `(f/c)·(û_tx + û_rx)·v`, so the flip made it `(−û_tx + û_rx)·v` — the terms nearly cancel, Doppler stops responding to velocity, and the solver settles on ground speed ≈ 0. Bistatic delay was unaffected (it uses vector magnitude only), so position looked roughly right while motion died.

## Fix
Flip the three TX components to match the reference forward model (`bistatic_models.bistatic_doppler`).

## Test
`test_vectorized_track_residual_matches_reference_doppler` rebuilds observations from the forward model and asserts the residual is ~0 — fails under the old sign. Full suite: 20 passed.