### PR TITLE
Fix Claude Code Review workflow so comments post on PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -38,7 +38,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
+          track_progress: true
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## Problem

The Claude Code Review workflow ran on PRs but **no review ever appeared**. Two
layers of permission denials caused this:

1. The job's `GITHUB_TOKEN` was scoped to `pull-requests: read` / `issues: read`,
   so every attempt to post was denied.
2. The `code-review` plugin buffers inline comments via
   `mcp__github_inline_comment__create_inline_comment`, which was not in Claude's
   allowed tools, so posts were denied even with write scope.

## Fix

- Grant `pull-requests: write` and `issues: write`.
- Add `--allowedTools` with the inline-comment MCP tool and `gh` commands so the
  plugin can buffer and post its review.
- Enable `track_progress: true` for a visible summary comment.

This mirrors the fix already applied to `tower-finder-service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
